### PR TITLE
#1 skip excluded properties

### DIFF
--- a/src/TypedPropertiesDriver.php
+++ b/src/TypedPropertiesDriver.php
@@ -33,6 +33,10 @@ class TypedPropertiesDriver implements DriverInterface
                 continue;
             }
 
+            if (!array_key_exists($property->getName(), $classMetadata->propertyMetadata)) {
+                continue;
+            }
+
             /**
              * @var PropertyMetadata $propertyMetadata
              */

--- a/tests/Stubs/Car.php
+++ b/tests/Stubs/Car.php
@@ -2,8 +2,12 @@
 
 namespace Gitnik\JmsTypedPropertiesDriver\Tests\Stubs;
 
+use JMS\Serializer\Annotation\Exclude;
+
 class Car {
     public int $horsePower;
     public Make $make;
     public string $color;
+    /** @Exclude() */
+    public string $hidden;
 }


### PR DESCRIPTION
Skip over any property that is not provided by the classMetadata object. Fixes #1